### PR TITLE
Pedir la lista de conversaciones y las conversaciones con los mensajes

### DIFF
--- a/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
+++ b/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
@@ -10,6 +10,14 @@ abstract class ConversationRemoteDataSource {
     required String userId,
     required String title,
   });
+  Future<List<ConversationEntity>> getConversations({
+    required String token,
+    String? type, // 'user' | 'tecnico'
+  });
+  Future<List<ConversationEntity>> getAllConversations({
+    required String token,
+    required String userId,
+  });
 }
 
 class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
@@ -44,6 +52,63 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
       return model.toEntity();
     } else {
       throw Exception('Failed to create conversation: ${response.statusCode} ${response.body}');
+    }
+  }
+
+  @override
+  Future<List<ConversationEntity>> getConversations({
+    required String token,
+    String? type,
+  }) async {
+    final path = type == null || type.isEmpty
+        ? '$_baseUrl/conversation'
+        : '$_baseUrl/conversation?type=$type';
+    final url = Uri.parse(path);
+
+    final response = await http.get(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      if (data is List) {
+        return data
+            .map((e) => ConversationsModel.fromJson(e).toEntity())
+            .toList();
+      } else {
+        throw Exception('Unexpected response format for conversations list');
+      }
+    } else {
+      throw Exception('Failed to fetch conversations: ${response.statusCode} ${response.body}');
+    }
+  }
+  
+  @override
+  Future<List<ConversationEntity>> getAllConversations({required String token, required String userId}) async {
+    final url = Uri.parse('$_baseUrl/conversation/all');
+    final response = await http.get(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      if (data is List) {
+        return data
+            .map((e) => ConversationsModel.fromJson(e).toEntity())
+            .toList();
+      } else {
+        throw Exception('Unexpected response format for conversations list');
+      }
+    } else {
+      throw Exception('Failed to fetch conversations: ${response.statusCode} ${response.body}');
     }
   }
 }

--- a/lib/feactures/conversation/data/models/conversations_model.dart
+++ b/lib/feactures/conversation/data/models/conversations_model.dart
@@ -46,7 +46,7 @@ class ConversationsModel {
     return ConversationEntity(
       id: id,
       title: title.isNotEmpty ? title : null,
-      messages: messages.map((messageId) => MessageEntity(id: messageId, content: '', senderId: '', timestamp: DateTime.now())).toList(),
+      messages: messages.map((messageId) => MessageEntity(id: messageId, content: '', timestamp: DateTime.now(), sender: '')).toList(),
       userId: userId, // Aquí deberías asignar el userId correspondiente
     );
   }

--- a/lib/feactures/conversation/data/repository_impl/conversation_repository_impl.dart
+++ b/lib/feactures/conversation/data/repository_impl/conversation_repository_impl.dart
@@ -43,4 +43,16 @@ class ConversationRepositoryImpl implements ConversationRepository {
     // TODO: implementar usando remoteDataSource cuando el endpoint esté disponible
     throw UnimplementedError();
   }
+  
+  @override
+  Future<ConversationEntity> getAllConversations(String token, String userId) {
+    // TODO: implement getAllConversations
+    throw UnimplementedError();
+  }
+  
+  @override
+  Future<String> getConversation(String conversationId) {
+    // TODO: implement getConversation
+    throw UnimplementedError();
+  }
 }

--- a/lib/feactures/conversation/domain/repository/conversation_reository.dart
+++ b/lib/feactures/conversation/domain/repository/conversation_reository.dart
@@ -7,6 +7,7 @@ abstract class ConversationRepository {
   Future<List<ConversationEntity>> getConversations();
   Future<void> deleteConversation(String conversationId);
   Future<void> updateConversation(String conversationId, String title, String description);
-  Future<String> getConversationDetails(String conversationId);  
+  Future<String> getConversation(String conversationId);  
+  Future<ConversationEntity> getAllConversations(String token, String userId);  
 
 } 

--- a/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:message_service/feactures/conversation/data/datasource/conversation_remote_datasource.dart';
 import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
 import 'package:meta/meta.dart';
 
@@ -6,9 +7,44 @@ part 'conversation_event.dart';
 part 'conversation_state.dart';
 
 class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
-  ConversationBloc({required conversationDataSource}) : super(ConversationInitial()) {
-    on<ConversationEvent>((event, emit) {
-      // TODO: implement event handler
-    });
+  final ConversationRemoteDataSource conversationDataSource;
+
+  ConversationBloc({required this.conversationDataSource}) : super(ConversationInitial()) {
+    on<CreateConversationEvent>(_onCreateConversation);
+    on<LoadConversationsEvent>(_onLoadConversations);
+  }
+
+  Future<void> _onCreateConversation(event, emit) async {
+    final previous = state;
+    emit(ConversationLoadingState());
+    try {
+      final newConv = await conversationDataSource.createConversation(
+        token: event.token,
+        userId: event.userId,
+        title: event.title,
+      );
+
+      if (previous is ConversationLoadedState) {
+        final updated = List<ConversationEntity>.from(previous.conversations)..insert(0, newConv);
+        emit(ConversationLoadedState(conversations: updated));
+      } else {
+        emit(ConversationLoadedState(conversations: [newConv]));
+      }
+    } catch (e) {
+      emit(ConversationErrorState(message: e.toString()));
+    }
+  }
+
+  Future<void> _onLoadConversations( event, emit ) async {
+    emit(ConversationLoadingState());
+    try {
+      final list = await conversationDataSource.getAllConversations(
+        token: event.token,
+        userId: event.userId,
+      );
+      emit(ConversationLoadedState(conversations: list));
+    } catch (e) {
+      emit(ConversationErrorState(message: e.toString()));
+    }
   }
 }

--- a/lib/feactures/conversation/presentation/bloc/conversation_event.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_event.dart
@@ -4,3 +4,22 @@ part of 'conversation_bloc.dart';
 
 @immutable
 sealed class ConversationEvent {}
+
+class CreateConversationEvent extends ConversationEvent {
+	final String token;
+	final String userId;
+	final String title;
+
+	CreateConversationEvent({
+		required this.token,
+		required this.userId,
+		required this.title,
+	});
+}
+
+	class LoadConversationsEvent extends ConversationEvent {
+		final String token;
+		final String? type; // 'user' | 'tecnico'
+
+		LoadConversationsEvent({required this.token, this.type});
+	}

--- a/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
+++ b/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
@@ -97,14 +97,28 @@ class _RoleCard extends StatelessWidget {
 }
 
 // Página que lista conversaciones (placeholder usando el Bloc existente)
-class ConversationListPage extends StatelessWidget {
+class ConversationListPage extends StatefulWidget {
   final String type; // 'user' o 'tecnico'
   const ConversationListPage({super.key, required this.type});
 
   @override
+  State<ConversationListPage> createState() => _ConversationListPageState();
+}
+
+class _ConversationListPageState extends State<ConversationListPage> {
+  @override
+  void initState() {
+    super.initState();
+    final authState = context.read<AuthBloc>().state;
+    if (authState is AuthAuthenticatedState) {
+      context.read<ConversationBloc>().add(LoadConversationsEvent(token: authState.user.token, type: widget.type));
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Lista de $type')),
+      appBar: AppBar(title: Text('Lista de ${widget.type}')),
       body: BlocBuilder<ConversationBloc, ConversationState>(
         builder: (context, state) {
           if (state is ConversationLoadingState) {
@@ -120,7 +134,7 @@ class ConversationListPage extends StatelessWidget {
                 final conversation = conversations[index];
                 return ListTile(
                   title: Text(conversation.title ?? 'Sin título'),
-                  subtitle: Text('Tipo: $type'),
+                  subtitle: Text('Tipo: ${widget.type}'),
                   onTap: () {},
                 );
               },
@@ -131,6 +145,61 @@ class ConversationListPage extends StatelessWidget {
           return const SizedBox.shrink();
         },
       ),
+    floatingActionButton: _NewConversationFab(type: widget.type),
+    );
+  }
+}
+
+class _NewConversationFab extends StatelessWidget {
+  final String type;
+  const _NewConversationFab({required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      tooltip: 'Nueva conversación',
+      child: const Icon(Icons.add),
+      onPressed: () async {
+        final titleController = TextEditingController();
+        final result = await showDialog<String>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('Nueva conversación'),
+            content: TextField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: 'Título',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancelar'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(ctx, titleController.text.trim()),
+                child: const Text('Crear'),
+              ),
+            ],
+          ),
+        );
+
+        if (result != null && result.isNotEmpty) {
+          final authState = context.read<AuthBloc>().state;
+          if (authState is AuthAuthenticatedState) {
+            final token = authState.user.token;
+            final userId = authState.user.id;
+            context.read<ConversationBloc>().add(
+              CreateConversationEvent(token: token, userId: userId, title: result),
+            );
+          } else {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Debes iniciar sesión')),
+            );
+          }
+        }
+      },
     );
   }
 }

--- a/lib/feactures/message/domain/entities/message_entity.dart
+++ b/lib/feactures/message/domain/entities/message_entity.dart
@@ -3,13 +3,13 @@
 class MessageEntity {
   final String id;
   final String content;
-  final String senderId;
+  final String sender;
   final DateTime timestamp;
 
   MessageEntity({
     required this.id,
     required this.content,
-    required this.senderId,
+    required this.sender,
     required this.timestamp,
   });
 
@@ -17,7 +17,7 @@ class MessageEntity {
     return MessageEntity(
       id: json['id'],
       content: json['content'],
-      senderId: json['senderId'],
+      sender: json['sender'],
       timestamp: DateTime.parse(json['timestamp']),
     );
   }
@@ -26,7 +26,7 @@ class MessageEntity {
     return {
       'id': id,
       'content': content,
-      'senderId': senderId,
+      'sender': sender,
       'timestamp': timestamp.toIso8601String(),
     };
   }

--- a/lib/feactures/message/presentation/bloc/message_bloc.dart
+++ b/lib/feactures/message/presentation/bloc/message_bloc.dart
@@ -43,7 +43,7 @@ class MessageBloc extends Bloc<MessageEvent, MessageState> {
         final messageEntity = MessageEntity(
           id: uuid.v4(), // Generate a unique ID for the message
           content: event.message,
-          senderId: userEntity.id, // Example sender ID
+          sender: userEntity.role, // Example sender ID
           timestamp: DateTime.now(),
         );
         await messageDataSource.sendMessage(messageEntity);


### PR DESCRIPTION
Se han incorporado varias funciones nuevas y refactorizaciones relacionadas con la gestión de conversaciones, incluyendo métodos de fuentes de datos remotas para obtener y crear conversaciones, gestión de eventos de bloque para acciones de conversación y mejoras en la interfaz de usuario para listar y crear conversaciones. También se han realizado cambios en el modelo y las entidades para lograr la coherencia en la representación de los mensajes.

**Mejoras en la fuente de datos de las conversaciones y el repositorio:**
- Se añadieron los métodos `getConversations` y `getAllConversations` a la clase abstracta `ConversationRemoteDataSource` y se implementaron en `ConversationRemoteDataSourceImpl` para permitir la obtención de conversaciones por tipo y la obtención de todas las conversaciones de un usuario. [[1]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48R13-R20) [[2]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48R57-R113)
- Se actualizó la interfaz `ConversationRepository` y su implementación para incluir métodos para obtener todas las conversaciones y recuperar una sola conversación, aunque las implementaciones actualmente no están implementadas. [[1]](diffhunk://#diff-fa172ab9128970c096d2139e26513606a1d72932f5ff452551cad9d9f6d3183fL10-R11) [[2]](diffhunk://#diff-7f76a4a9898b89f45b3c8d3f35fe06fbbf3132c391b8c6f6beaa8dfda25e7907R46-R57)

**Gestión de bloques y eventos:**
- Se refactorizó `ConversationBloc` para gestionar `CreateConversationEvent` y `LoadConversationsEvent`, lo que permite que el bloque cree nuevas conversaciones y las cargue desde la fuente de datos remota. [[1]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bR2-R48) [[2]](diffhunk://#diff-704ca347ecf6846f054a5fc6f2ee898b64c4f47b9aad53dbfd31e2a6d70d3e32R7-R25)

**Mejoras en la interfaz de usuario para el listado de conversaciones:**
- Se refactorizó `ConversationListPage` de un widget sin estado a uno con estado para cargar automáticamente las conversaciones al inicializarse y mostrarlas usando el estado del bloque. Se añadió un botón de acción flotante para crear nuevas conversaciones mediante un cuadro de diálogo. [[1]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L100-R121) [[2]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L123-R137) [[3]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2R148-R202)

**Consistencia de modelo y entidad:**
- Se actualizaron las conversiones de `MessageEntity` y las relacionadas para usar el campo `sender` en lugar de `senderId` para mantener la coherencia en todo el código. [[1]](diffhunk://#diff-521a0af895225c3c08a50ad78bcfcc011a798bc7b82a49fe09406412d0a19180L6-R20) [[2]](diffhunk://#diff-521a0af895225c3c08a50ad78bcfcc011a798bc7b82a49fe09406412d0a19180L29-R29) [[3]](diffhunk://#diff-ba0f51c18e312b9d7488bea5da15b7bdd8e938963aee07c88e59d49a05f9449fL46-R46)
- Se ajustó el método `ConversationsModel.toEntity` para que coincida con el constructor `MessageEntity` actualizado.