### PR TITLE
Capturando el role para el tipo de conversacion

### DIFF
--- a/lib/feactures/auth/data/models/user_model.dart
+++ b/lib/feactures/auth/data/models/user_model.dart
@@ -14,13 +14,27 @@ class UserModel extends UserEntity{
 
   // Convierte un mapa a una instancia de UserModel
   factory UserModel.fromJson(json){
+    // El servidor devuelve siempre `roles` como array. Extraemos y normalizamos
+    const allowed = ['sales', 'tecnico', 'user'];
+    String roleValue = 'user';
+
+    final dynamic rolesField = json != null ? json['roles'] : null;
+    if (rolesField is List) {
+      final extracted = rolesField
+          .map((e) => e.toString().toLowerCase().trim())
+          .where((r) => allowed.contains(r))
+          .toList();
+      if (extracted.isNotEmpty) {
+        roleValue = extracted.join(',');
+      }
+    }
+
     return UserModel(
       id      : json['id'],
       fullName: json['fullName'],
       email   : json['email'],
       token   : json['token'],
-      role    : json['role'] ?? 'user',
-// Maneja el caso de imageUrl nulo
+      role    : roleValue,
     );
   }
   // Convierte una instancia de UserModel a un mapa

--- a/lib/feactures/auth/domain/entities/user.dart
+++ b/lib/feactures/auth/domain/entities/user.dart
@@ -19,4 +19,23 @@ class UserEntity {
   String toString() {
     return 'User(id: $id, name: $fullName, email: $email, token: $token, role: $role)';
   }
+
+  /// Devuelve true si el usuario tiene el rol indicado.
+  /// Soporta valores compuestos en `role` separados por comas, por ejemplo: 'tecnico,sales'
+  bool hasRole(String r) {
+    final wanted = r.toLowerCase().trim();
+    final current = role
+        .toLowerCase()
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+    if (current.contains('both')) return true; // valor especial aceptado
+
+    // Valid roles declared by the server
+    const allowed = ['sales', 'tecnico', 'user'];
+    if (!allowed.contains(wanted)) return false;
+
+    return current.contains(wanted);
+  }
 }

--- a/lib/feactures/auth/presentation/ui/pages/login_page.dart
+++ b/lib/feactures/auth/presentation/ui/pages/login_page.dart
@@ -16,12 +16,10 @@ class Login extends StatelessWidget {
       body: BlocListener<AuthBloc, AuthState>(
         listener: (context, state) {
           if (state is AuthAuthenticatedState) {
-            //state.user.saveUser();
+            // After login, go to the Conversation selection page (cards)
             Navigator.pushReplacement(
               context,
-              MaterialPageRoute(
-                builder: (_) => const ConversationPage(),
-              ),
+              MaterialPageRoute(builder: (_) => const ConversationPage()),
             );
           }
         },
@@ -74,7 +72,7 @@ class Login extends StatelessWidget {
                         // Directly navigate to the anonymous conversations list.
                         Navigator.pushReplacement(
                           context,
-                          MaterialPageRoute(builder: (_) => const ConversationListPage(type: 'anonymous')),
+                          MaterialPageRoute(builder: (_) => const ConversationPage()),
                         );
                       },
                       child: const Text('Entrar como invitado'),

--- a/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
+++ b/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
@@ -6,9 +6,10 @@ import 'package:message_service/feactures/conversation/domain/entities/conversti
 
 abstract class ConversationRemoteDataSource {
   Future<ConversationEntity> createConversation({
-    required String token,
-    required String userId,
-    required String title,
+  required String token,
+  required String userId,
+  required String title,
+  String? type,
   });
   Future<List<ConversationEntity>> getConversations({
     required String token,
@@ -32,8 +33,24 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
     required String token,
     required String userId,
     required String title,
+    String? type,
   }) async {
-    final url = Uri.parse('$_baseUrl/conversation/create');
+    // Choose exact backend endpoints for role-specific creation
+    String path;
+    if (type != null && type.isNotEmpty) {
+      final t = type.toLowerCase();
+      if (t == 'tecnico' || t == 'technical') {
+        path = '$_baseUrl/conversation/create-tecnico';
+      } else if (t == 'sales' || t == 'seller' || t == 'vendedor') {
+        path = '$_baseUrl/conversation/create-sales';
+      } else {
+        // unknown type: fallback to default create
+        path = '$_baseUrl/conversation/create';
+      }
+    } else {
+      path = '$_baseUrl/conversation/create';
+    }
+    final url = Uri.parse(path);
     final headers = {
       'Content-Type': 'application/json',
     };

--- a/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
@@ -51,6 +51,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         token: event.token,
         userId: event.userId,
         title: event.title,
+        type: (event as dynamic).type,
       );
 
       // If backend returned a session token (conversación anónima), store and connect
@@ -66,11 +67,11 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
 
       if (previous is ConversationLoadedState) {
         final updated = List<ConversationEntity>.from(previous.conversations)..insert(0, newConv);
-  emit(ConversationLoadedState(conversations: updated));
-  emit(ConversationCreatedState(conversation: newConv));
+        emit(ConversationLoadedState(conversations: updated));
+        emit(ConversationCreatedState(conversation: newConv));
       } else {
-  emit(ConversationLoadedState(conversations: [newConv]));
-  emit(ConversationCreatedState(conversation: newConv));
+        emit(ConversationLoadedState(conversations: [newConv]));
+        emit(ConversationCreatedState(conversation: newConv));
       }
     } catch (e) {
       emit(ConversationErrorState(message: e.toString()));

--- a/lib/feactures/conversation/presentation/bloc/conversation_event.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_event.dart
@@ -9,11 +9,13 @@ class CreateConversationEvent extends ConversationEvent {
 	final String token;
 	final String userId;
 	final String title;
+	final String? type; // optional: 'user' | 'tecnico' | 'sales' | 'anonymous'
 
 	CreateConversationEvent({
 		required this.token,
 		required this.userId,
 		required this.title,
+		this.type,
 	});
 }
 

--- a/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
+++ b/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
@@ -1,60 +1,117 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:message_service/feactures/auth/presentation/bloc/auth_bloc.dart';
-import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
 import 'package:message_service/feactures/conversation/presentation/bloc/conversation_bloc.dart';
-import 'package:message_service/feactures/message/presentation/ui/pages/message_page.dart';
-import 'package:message_service/core/session_manager.dart';
-import 'package:message_service/core/services/socket_service.dart';
-import 'package:message_service/feactures/message/data/datasource/message_remote_datasource.dart';
-import 'package:message_service/feactures/message/data/datasource/local_message_datasource.dart';
-import 'package:message_service/feactures/message/domain/entities/message_entity.dart';
+import 'package:message_service/feactures/auth/presentation/ui/pages/login_page.dart';
 
-// Página menú según rol
+// Página menú según rol (minimal y estable)
 class ConversationPage extends StatelessWidget {
   const ConversationPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     final authState = context.watch<AuthBloc>().state;
-    String role = 'user';
-    if (authState is AuthAuthenticatedState) {
-      role = authState.user.role;
+
+    // TODO(debug): temporal - imprimir role del usuario para depuración
+    try {
+      if (authState is AuthAuthenticatedState) {
+        // imprimir solo en modo debug para no saturar logs en release
+        // ignore: avoid_print
+        print('[DEBUG] ConversationPage auth user role: "${authState.user.role}"');
+      } else {
+        // ignore: avoid_print
+        print('[DEBUG] ConversationPage auth state: ${authState.runtimeType}');
+      }
+    } catch (e) {
+      // ignore: avoid_print
+      print('[DEBUG] ConversationPage error al leer authState: $e');
     }
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Conversaciones')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            _RoleCard(
-              title: 'Conversaciones usuario',
-              icon: Icons.chat_bubble_outline,
-              color: Colors.blue,
-              onTap: () => _openList(context, 'user'),
-            ),
-            if (role.toLowerCase() == 'tecnico') ...[
-              const SizedBox(height: 16),
+    // Usuario no autenticado: solo tarjeta anonymous
+    if (authState is! AuthAuthenticatedState) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Conversaciones')),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
               _RoleCard(
-                title: 'Conversaciones técnico',
-                icon: Icons.build_outlined,
-                color: Colors.deepPurple,
-                onTap: () => _openList(context, 'tecnico'),
+                title: 'Conversaciones anónimas',
+                icon: Icons.person_outline,
+                color: Colors.grey,
+                onTap: () => _openList(context, 'anonymous'),
               ),
             ],
-          ],
+          ),
         ),
-      ),
+      );
+    }
+
+  // Usuario autenticado: mostrar tarjetas según roles
+  final user = authState.user;
+
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<ConversationBloc, ConversationState>(
+          listener: (context, state) {
+            if (state is ConversationErrorState) {
+              final msg = state.message.isNotEmpty ? state.message : 'Error de conexión';
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(SnackBar(content: Text(msg), backgroundColor: Colors.red));
+            }
+          },
+        ),
+        BlocListener<AuthBloc, AuthState>(
+          listener: (context, state) {
+            if (state is AuthAuthenticatedState) {
+              Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => Login()));
+            }
+          },
+        ),
+      ],
+      child: Builder(builder: (context) {
+        // Sólo leer LO NECESARIO del AuthBloc: evita rebuilds por cambios irrelevantes
+        final String? role = context.select<AuthBloc, String?>((bloc) {
+          final s = bloc.state;
+          return s is AuthAuthenticatedState ? s.user.role : null;
+        });
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('Conversaciones')),
+          body: Column(
+            children: [
+              // UI condicional por role (reconstruye solo si cambia role)
+              if (role != null && role.contains('sales')) ...[
+                _RoleCard(
+                  title: 'Conversaciones vendedores',
+                  icon: Icons.storefront_outlined,
+                  color: Colors.orange,
+                  onTap: () => _openList(context, 'sales'),
+                ),
+                const SizedBox(height: 16),
+              ],
+              // Parte que depende del ConversationBloc: usar BlocBuilder
+              Expanded(
+                child: BlocBuilder<ConversationBloc, ConversationState>(
+                  builder: (context, convState) {
+                    if (convState is ConversationLoadingState) return const Center(child: CircularProgressIndicator());
+                    if (convState is ConversationLoadedState) return ListView(/*...*/);
+                    if (convState is ConversationErrorState) return Center(child: Text('Error: ${convState.message}'));
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
     );
   }
 
   void _openList(BuildContext context, String type) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => ConversationListPage(type: type)),
-    );
+    Navigator.push(context, MaterialPageRoute(builder: (_) => ConversationListPage(type: type)));
   }
 }
 
@@ -63,230 +120,38 @@ class _RoleCard extends StatelessWidget {
   final IconData icon;
   final Color color;
   final VoidCallback onTap;
-  const _RoleCard({
-    required this.title,
-    required this.icon,
-    required this.color,
-    required this.onTap,
-  });
+  const _RoleCard({required this.title, required this.icon, required this.color, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     return Card(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       elevation: 2,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
+      child: ListTile(
+        leading: CircleAvatar(backgroundColor: color.withOpacity(0.12), child: Icon(icon, color: color)),
+        title: Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+        trailing: const Icon(Icons.chevron_right),
         onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Row(
-            children: [
-              CircleAvatar(
-                backgroundColor: color.withOpacity(0.15),
-                child: Icon(icon, color: color),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Text(
-                  title,
-                  style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-                ),
-              ),
-              const Icon(Icons.chevron_right),
-            ],
-          ),
-        ),
       ),
     );
   }
 }
 
-// Página que lista conversaciones (placeholder usando el Bloc existente)
-class ConversationListPage extends StatefulWidget {
-  final String type; // 'user' o 'tecnico'
+class ConversationListPage extends StatelessWidget {
+  final String type;
   const ConversationListPage({super.key, required this.type});
-
-  @override
-  State<ConversationListPage> createState() => _ConversationListPageState();
-}
-
-class _ConversationListPageState extends State<ConversationListPage> {
-  @override
-  void initState() {
-    super.initState();
-    final authState = context.read<AuthBloc>().state;
-    if (authState is AuthAuthenticatedState) {
-      context.read<ConversationBloc>().add(LoadConversationsEvent(token: authState.user.token, type: widget.type));
-    } else {
-      // anonymous: load public/anonymous conversations (backend should support type='anonymous')
-      context.read<ConversationBloc>().add(LoadConversationsEvent(token: '', type: 'anonymous'));
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-  appBar: AppBar(title: Text('Lista de ${widget.type}')),
-      body: BlocListener<ConversationBloc, ConversationState>(
-        listener: (context, state) {
-          if (state is ConversationCreatedState) {
-            // navigate to message page for the created conversation (push so user can go back)
-            Navigator.push(context, MaterialPageRoute(builder: (_) => MessagePage(conversationId: state.conversation.id, title: state.conversation.title ?? 'Conversación', initialMessages: state.conversation.messages?.map((m) => m.toJson()).toList())));
-          }
-        },
-        child: BlocBuilder<ConversationBloc, ConversationState>(
-          builder: (context, state) {
-          if (state is ConversationLoadingState) {
-            return const Center(child: CircularProgressIndicator());
-          } else if (state is ConversationLoadedState) {
-            final List<ConversationEntity> conversations = state.conversations;
-            if (conversations.isEmpty) {
-              return const Center(child: Text('No hay conversaciones.'));
-            }
-            return ListView.builder(
-              padding: const EdgeInsets.all(12),
-              itemCount: conversations.length,
-              itemBuilder: (context, index) {
-                final conversation = conversations[index];
-                final displayTitle = conversation.title ?? 'Sin título';
-                final created = conversation.createdAt;
-                final dateText = created != null ?
-                  '${created.toLocal().day}/${created.toLocal().month}/${created.toLocal().year} ${created.toLocal().hour}:${created.toLocal().minute.toString().padLeft(2,'0')}'
-                  : '';
-
-                return Dismissible(
-                  key: Key(conversation.id),
-                  direction: DismissDirection.endToStart,
-                  background: Container(
-                    alignment: Alignment.centerRight,
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    color: Colors.red,
-                    child: const Icon(Icons.delete, color: Colors.white),
-                  ),
-                  onDismissed: (_) {
-                    // Dispatch delete event to bloc (incluir token si el usuario está autenticado)
-                    final authState = context.read<AuthBloc>().state;
-                    final token = (authState is AuthAuthenticatedState) ? authState.user.token : '';
-                    context.read<ConversationBloc>().add(DeleteConversationEvent(conversationId: conversation.id, token: token, sessionToken: conversation.sessionToken));
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Conversación eliminada')));
-                  },
-                  child: Card(
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                    elevation: 2,
-                    margin: const EdgeInsets.symmetric(vertical: 8),
-                    child: ListTile(
-                      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      // Mostrar la fecha arriba y el título debajo
-                      title: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            dateText,
-                            style: const TextStyle(fontSize: 12, color: Colors.grey),
-                          ),
-                          const SizedBox(height: 6),
-                          Text(
-                            displayTitle,
-                            style: const TextStyle(fontWeight: FontWeight.w600),
-                          ),
-                        ],
-                      ),
-                      onTap: () async {
-                        // If conversation has sessionToken, store it so MessageDataSource will use it
-                        if (conversation.sessionToken != null && conversation.sessionToken!.isNotEmpty) {
-                          SessionManager().sessionToken = conversation.sessionToken;
-                          SessionManager().conversationId = conversation.id;
-                          // Ensure socket connects using anonymous session
-                          try {
-                            SocketService().connect(token: '');
-                          } catch (_) {}
-                        }
-
-                        final convId = conversation.id;
-                        final localDs = LocalMessageDataSource();
-
-                        // 1) Intentar obtener mensajes desde DB local
-                        try {
-                          final localList = await localDs.getMessages(convId);
-                          if (localList.isNotEmpty) {
-                            final serializedLocal = localList.map((m) => m.toJson()).toList();
-                            Navigator.push(context, MaterialPageRoute(builder: (_) => MessagePage(conversationId: convId, title: conversation.title ?? 'Conversación', initialMessages: serializedLocal)));
-                            return;
-                          }
-                        } catch (_) {
-                          // ignore and try other sources
-                        }
-
-                        // 2) Si no hay local en DB, comprobar SessionManager temporal y migrar a DB si existe
-                        try {
-                          final temp = SessionManager().messagesByConversation[convId];
-                          if (temp != null && temp.isNotEmpty) {
-                            for (final m in temp) {
-                              final content = m['text']?.toString() ?? '';
-                              final sender = m['sender']?.toString() ?? '';
-                              final createdRaw = m['created_at']?.toString() ?? '';
-                              DateTime createdAt;
-                              try {
-                                createdAt = DateTime.parse(createdRaw).toUtc();
-                              } catch (_) {
-                                createdAt = DateTime.now().toUtc();
-                              }
-                              final entity = MessageEntity(id: UniqueKey().toString(), content: content, sender: sender, created_at: createdAt);
-                              try {
-                                await localDs.insertMessage(convId, entity);
-                              } catch (_) {}
-                            }
-                            final migrated = await localDs.getMessages(convId);
-                            final serializedLocal = migrated.map((m) => m.toJson()).toList();
-                            Navigator.push(context, MaterialPageRoute(builder: (_) => MessagePage(conversationId: convId, title: conversation.title ?? 'Conversación', initialMessages: serializedLocal)));
-                            return;
-                          }
-                        } catch (_) {
-                          // ignore
-                        }
-
-                        // 3) Si no hay datos locales, pedir historial al servidor y persistirlo
-                        try {
-                          final remote = MessageRemoteDataSourceImpl();
-                          final authState = context.read<AuthBloc>().state;
-                          final token = (authState is AuthAuthenticatedState) ? authState.user.token : '';
-                          final msgs = await remote.getMessages(token: token, conversationId: convId);
-                          final serialized = msgs.map((m) => m.toJson()).toList();
-                          // Guardar temporal y persistir en DB
-                          try {
-                            SessionManager().messagesByConversation[convId] = serialized.map((e) => {'text': e['content'] ?? e['message'] ?? '', 'sender': e['sender'] ?? '', 'created_at': e['created_at'] ?? ''}).toList();
-                          } catch (_) {}
-                          try {
-                            for (final m in msgs) {
-                              await localDs.insertMessage(convId, m);
-                            }
-                          } catch (_) {}
-                          Navigator.push(context, MaterialPageRoute(builder: (_) => MessagePage(conversationId: convId, title: conversation.title ?? 'Conversación', initialMessages: serialized)));
-                          return;
-                        } catch (_) {
-                          // Si falla la petición remota, abrir con lo que haya en la entidad conversation
-                          Navigator.push(context, MaterialPageRoute(builder: (_) => MessagePage(conversationId: convId, title: conversation.title ?? 'Conversación', initialMessages: conversation.messages?.map((m) => m.toJson()).toList())));
-                          return;
-                        }
-                      },
-                    ),
-                  ),
-                );
-              },
-            );
-          } else if (state is ConversationErrorState) {
-            return Center(child: Text('Error: ${state.message}'));
-          }
-          return const SizedBox.shrink();
-          },
-        ),
-      ),
-    floatingActionButton: _NewConversationFab(type: widget.type),
+      appBar: AppBar(title: Text('Lista de $type')),
+      body: Center(child: Text('Aquí iría la lista de conversaciones de tipo "$type"')),
+      floatingActionButton: _NewConversationFab(type: type),
     );
   }
 }
 
+// FAB compacto con validación de roles antes de crear conversación
 class _NewConversationFab extends StatelessWidget {
   final String type;
   const _NewConversationFab({required this.type});
@@ -302,40 +167,41 @@ class _NewConversationFab extends StatelessWidget {
           context: context,
           builder: (ctx) => AlertDialog(
             title: const Text('Nueva conversación'),
-            content: TextField(
-              controller: titleController,
-              decoration: const InputDecoration(
-                labelText: 'Título',
-                border: OutlineInputBorder(),
-              ),
-            ),
+            content: TextField(controller: titleController, decoration: const InputDecoration(labelText: 'Título')),
             actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx),
-                child: const Text('Cancelar'),
-              ),
-              ElevatedButton(
-                onPressed: () => Navigator.pop(ctx, titleController.text.trim()),
-                child: const Text('Crear'),
-              ),
+              TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
+              ElevatedButton(onPressed: () => Navigator.pop(ctx, titleController.text.trim()), child: const Text('Crear')),
             ],
           ),
         );
 
-        if (result != null && result.isNotEmpty) {
-          final authState = context.read<AuthBloc>().state;
-          if (authState is AuthAuthenticatedState) {
-            final token = authState.user.token;
-            final userId = authState.user.id;
-            context.read<ConversationBloc>().add(
-              CreateConversationEvent(token: token, userId: userId, title: result),
-            );
-          } else {
-            // anonymous creation: pass empty token/userId; server will create an anonymous conversation and return session_token
-            context.read<ConversationBloc>().add(
-              CreateConversationEvent(token: '', userId: '', title: result),
-            );
+        if (result == null || result.isEmpty) return;
+
+        final authState = context.read<AuthBloc>().state;
+        if (authState is AuthAuthenticatedState) {
+          final user = authState.user;
+          if (type != 'anonymous' && !user.hasRole(type)) {
+            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('No tienes permisos para crear conversaciones de tipo "$type".')));
+            return;
           }
+          context.read<ConversationBloc>().add(CreateConversationEvent(token: user.token, userId: user.id, title: result, type: type));
+        } else {
+          if (type != 'anonymous') {
+            final goLogin = await showDialog<bool>(
+              context: context,
+              builder: (ctx) => AlertDialog(
+                title: const Text('Acceso restringido'),
+                content: const Text('Debes iniciar sesión para crear o ver este tipo de conversaciones. ¿Ir al login?'),
+                actions: [
+                  TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancelar')),
+                  ElevatedButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Ir al login')),
+                ],
+              ),
+            );
+            if (goLogin == true) Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => Login()));
+            return;
+          }
+          context.read<ConversationBloc>().add(CreateConversationEvent(token: '', userId: '', title: result, type: 'anonymous'));
         }
       },
     );


### PR DESCRIPTION
Introduce mejoras significativas en la gestión de roles de usuario y en la adaptación de la interfaz de usuario de las conversaciones a dichos roles. Refactoriza la gestión de roles para admitir múltiples roles por usuario, actualiza el flujo de creación de conversaciones para usar puntos de conexión de backend específicos para cada rol y simplifica la interfaz de usuario para listar conversaciones por rol. Los cambios más importantes son los siguientes:

**Gestión y normalización de roles:**

* La fábrica `UserModel.fromJson` ahora extrae, normaliza y almacena los roles de usuario como una cadena separada por comas, lo que permite la gestión de múltiples roles por usuario (p. ej., `'tecnico,sales'`). Solo se consideran los roles permitidos.
* Se añade un nuevo método `hasRole` a `UserEntity` para buscar un rol específico, admitiendo cadenas de roles compuestas y un valor especial `'both'`.

**Creación de conversaciones y flujo de datos:**

* La API de creación de conversaciones ahora acepta un parámetro `type` opcional y dirige las solicitudes a puntos finales de backend específicos del rol (`/create-tecnico`, `/create-sales` o predeterminado) según el tipo de rol proporcionado. [[1]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48R12) [[2]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48R36-R53)
* El `CreateConversationEvent` y su uso en `ConversationBloc` se actualizan para incluir el parámetro opcional `type`, lo que garantiza que se utilice el punto final correcto durante la creación de la conversación. [[1]](diffhunk://#diff-704ca347ecf6846f054a5fc6f2ee898b64c4f47b9aad53dbfd31e2a6d70d3e32R12-R18) [[2]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bR54)

**Refactorización de la interfaz de usuario y navegación basada en roles:**

* La interfaz de usuario «ConversationPage» se ha refactorizado para mostrar tarjetas y acciones según los roles de los usuarios autenticados. Solo se muestran los tipos de conversación relevantes y la interfaz de usuario se ha optimizado para evitar reconstrucciones innecesarias. Los usuarios anónimos solo ven la tarjeta de conversación anónima. [[1]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L4-R31) [[2]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L33-R114)
* El widget `_RoleCard` se ha simplificado para mayor claridad, y el widget `ConversationListPage` se ha refactorizado de un widget con estado a uno sin estado, con un marcador de posición para la lista de conversaciones. El botón de acción flotante (`_NewConversationFab`) se mantiene para crear nuevas conversaciones por rol.

**Mejoras de navegación:**

* Tras iniciar sesión o al acceder como invitado, la navegación se ha optimizado para dirigirse siempre a la página principal de conversación, unificando así el punto de entrada para todos los usuarios. [[1]](diffhunk://#diff-591e70d3e510d8b40782ad0945bad7ef3da4ed3ab49bae1a28d45a1d72fc1a02L19-R22) [[2]](diffhunk://#diff-591e70d3e510d8b40782ad0945bad7ef3da4ed3ab49bae1a28d45a1d72fc1a02L77-R75)