### PR TITLE
Creando conversaciones de usuarios logueados

### DIFF
--- a/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
+++ b/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
@@ -39,9 +39,9 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
     String path;
     if (type != null && type.isNotEmpty) {
       final t = type.toLowerCase();
-      if (t == 'tecnico' || t == 'technical') {
+      if ( t == 'tecnico' ) {
         path = '$_baseUrl/conversation/create-tecnico';
-      } else if (t == 'sales' || t == 'seller' || t == 'vendedor') {
+      } else if ( t == 'sales' ) {
         path = '$_baseUrl/conversation/create-sales';
       } else {
         // unknown type: fallback to default create
@@ -55,12 +55,13 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
       'Content-Type': 'application/json',
     };
     if (token.isNotEmpty) {
-      headers['auth'] = token;
+      headers['Authorization'] = 'Bearer $token';
     }
     final payload = <String, dynamic>{'title': title};
     // "user" must be a UUID and only sent when the user is authenticated
     if (userId.isNotEmpty) {
       payload['user'] = userId;
+      payload['type'] = type;
     }
 
     final response = await http.post(
@@ -93,7 +94,7 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
       'Content-Type': 'application/json',
     };
     if (token.isNotEmpty) {
-      headers['auth'] = token;
+      headers['Authorization'] = 'Bearer $token';
     }
     final response = await http.get(
       url,
@@ -121,7 +122,7 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
       'Content-Type': 'application/json',
     };
     if (token.isNotEmpty) {
-      headers['auth'] = token;
+      headers['Authorization'] = 'Bearer $token';
     }
     final response = await http.get(
       url,
@@ -152,7 +153,7 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
     final headers = {
       'Content-Type': 'application/json',
     };
-    if (token.isNotEmpty) headers['auth'] = token;
+    if (token.isNotEmpty) headers['Authorization'] = 'Bearer $token';
 
     final response = await http.delete(url, headers: headers);
     if (response.statusCode == 200 || response.statusCode == 204) {

--- a/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
+++ b/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
@@ -10,17 +10,26 @@ class ConversationPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final authState = context.watch<AuthBloc>().state;
+    final String? userRole = context.select<AuthBloc, String?>((bloc) {
+      final st = bloc.state;
+      if (st is AuthAuthenticatedState) return st.user.role; // ej "sales,tecnico" o "sales"
+      return null;
+    });
+
+    final bool isAuthenticated = userRole != null;
+    final roles = (userRole ?? '').split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+    final bool hasSales = roles.contains('sales');
+    final bool hasTecnico = roles.contains('tecnico');
 
     // TODO(debug): temporal - imprimir role del usuario para depuración
     try {
-      if (authState is AuthAuthenticatedState) {
+      if (isAuthenticated) {
         // imprimir solo en modo debug para no saturar logs en release
         // ignore: avoid_print
-        print('[DEBUG] ConversationPage auth user role: "${authState.user.role}"');
+        print('[DEBUG] ConversationPage auth user role: "$userRole"');
       } else {
         // ignore: avoid_print
-        print('[DEBUG] ConversationPage auth state: ${authState.runtimeType}');
+        print('[DEBUG] ConversationPage auth state: ${userRole.runtimeType}');
       }
     } catch (e) {
       // ignore: avoid_print
@@ -28,7 +37,7 @@ class ConversationPage extends StatelessWidget {
     }
 
     // Usuario no autenticado: solo tarjeta anonymous
-    if (authState is! AuthAuthenticatedState) {
+    if (!isAuthenticated) {
       return Scaffold(
         appBar: AppBar(title: const Text('Conversaciones')),
         body: Padding(
@@ -48,8 +57,7 @@ class ConversationPage extends StatelessWidget {
       );
     }
 
-  // Usuario autenticado: mostrar tarjetas según roles
-  final user = authState.user;
+    // Usuario autenticado: mostrar tarjetas según roles
 
     return MultiBlocListener(
       listeners: [
@@ -72,38 +80,52 @@ class ConversationPage extends StatelessWidget {
         ),
       ],
       child: Builder(builder: (context) {
-        // Sólo leer LO NECESARIO del AuthBloc: evita rebuilds por cambios irrelevantes
-        final String? role = context.select<AuthBloc, String?>((bloc) {
-          final s = bloc.state;
-          return s is AuthAuthenticatedState ? s.user.role : null;
-        });
-
         return Scaffold(
           appBar: AppBar(title: const Text('Conversaciones')),
-          body: Column(
-            children: [
-              // UI condicional por role (reconstruye solo si cambia role)
-              if (role != null && role.contains('sales')) ...[
+          body: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
                 _RoleCard(
-                  title: 'Conversaciones vendedores',
-                  icon: Icons.storefront_outlined,
-                  color: Colors.orange,
-                  onTap: () => _openList(context, 'sales'),
+                  title: 'Conversaciones anónimas',
+                  icon: Icons.person_outline,
+                  color: Colors.grey,
+                  onTap: () => _openList(context, 'anonymous'),
                 ),
                 const SizedBox(height: 16),
-              ],
-              // Parte que depende del ConversationBloc: usar BlocBuilder
-              Expanded(
-                child: BlocBuilder<ConversationBloc, ConversationState>(
-                  builder: (context, convState) {
-                    if (convState is ConversationLoadingState) return const Center(child: CircularProgressIndicator());
-                    if (convState is ConversationLoadedState) return ListView(/*...*/);
-                    if (convState is ConversationErrorState) return Center(child: Text('Error: ${convState.message}'));
-                    return const SizedBox.shrink();
-                  },
+                // Mostrar técnico si tiene el rol tecnico
+                if (hasTecnico) ...[
+                  _RoleCard(
+                    title: 'Conversaciones técnico',
+                    icon: Icons.build_outlined,
+                    color: Colors.deepPurple,
+                    onTap: () => _openList(context, 'tecnico'),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                // Mostrar ventas si tiene el rol sales
+                if (hasSales) ...[
+                  _RoleCard(
+                    title: 'Conversaciones vendedores',
+                    icon: Icons.storefront_outlined,
+                    color: Colors.orange,
+                    onTap: () => _openList(context, 'sales'),
+                  ),
+                ],
+                // Parte que depende del ConversationBloc: usar BlocBuilder
+                Expanded(
+                  child: BlocBuilder<ConversationBloc, ConversationState>(
+                    builder: (context, convState) {
+                      if (convState is ConversationLoadingState) return const Center(child: CircularProgressIndicator());
+                      if (convState is ConversationLoadedState) return ListView(/*...*/);
+                      if (convState is ConversationErrorState) return Center(child: Text('Error: ${convState.message}'));
+                      return const SizedBox.shrink();
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         );
       }),


### PR DESCRIPTION
Se refactorizó la fuente de datos del backend y la interfaz de usuario (IU) de las conversaciones para mejorar la gestión de roles, la autorización y la claridad. Los cambios más significativos son la estandarización de los encabezados de autorización HTTP, un análisis de roles más robusto en la IU y una representación condicional más clara de las tarjetas de conversación según los roles de usuario.

**Mejoras del backend (Fuente de datos):**
* Se estandarizó el encabezado de autorización HTTP, pasando de un encabezado `'auth'` personalizado al formato estándar `'Authorization': 'Bearer $token'`, en todas las solicitudes HTTP en `ConversationRemoteDataSourceImpl` (`conversation_remote_datasource.dart`). [[1]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48L58-R64) [[2]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48L96-R97) [[3]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48L124-R125) [[4]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48L155-R156)
* Se perfeccionó la lógica de enrutamiento de tipos de conversación para buscar únicamente coincidencias exactas (`'técnico'` y `'ventas'`), eliminando la compatibilidad con sinónimos como `'técnico'`, `'vendedor'` o `'vendedor'`.
* Se aseguró que el `tipo` se incluya en la carga útil solo cuando un usuario esté autenticado.

**Mejoras en la interfaz de usuario (IU):**
* Se mejoró la extracción de roles leyendo la cadena de rol del usuario una sola vez y dividiéndola en una lista, lo que permite una lógica de IU basada en roles más flexible y eficiente en `ConversationPage`. * Renderizado condicional refactorizado: La interfaz de usuario ahora muestra las tarjetas para las conversaciones de "técnico" y "ventas" solo si el usuario tiene el rol correspondiente, y siempre muestra la tarjeta anónima. La lógica es más clara y evita reconstrucciones innecesarias de bloques. [[1]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L75-L93) [[2]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2R129)
* Se eliminaron las variables no utilizadas y se limpió el registro de depuración para los roles de usuario. [[1]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L52) [[2]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L13-R40)