### PR TITLE
Guardando las conv en local, por que no se pueden identificar las anonimas

### DIFF
--- a/lib/core/local_database.dart
+++ b/lib/core/local_database.dart
@@ -38,6 +38,19 @@ class LocalDatabase {
             created_at TEXT
           )
         ''');
+        // Nueva tabla para persistir conversaciones localmente con columna 'type'
+        await db.execute('''
+          CREATE TABLE conversations (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            user_id TEXT,
+            session_token TEXT,
+            type TEXT,
+            metadata TEXT,
+            created_at TEXT,
+            updated_at TEXT
+          )
+        ''');
       },
     );
   }

--- a/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
+++ b/lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart
@@ -9,7 +9,7 @@ abstract class ConversationRemoteDataSource {
   required String token,
   required String userId,
   required String title,
-  String? type,
+  required String type,
   });
   Future<List<ConversationEntity>> getConversations({
     required String token,
@@ -59,9 +59,9 @@ class ConversationRemoteDataSourceImpl implements ConversationRemoteDataSource {
     }
     final payload = <String, dynamic>{'title': title};
     // "user" must be a UUID and only sent when the user is authenticated
+    payload['type'] = type;
     if (userId.isNotEmpty) {
       payload['user'] = userId;
-      payload['type'] = type;
     }
 
     final response = await http.post(

--- a/lib/feactures/conversation/data/datasource/local_conversation_datasource.dart
+++ b/lib/feactures/conversation/data/datasource/local_conversation_datasource.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:message_service/core/local_database.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:message_service/feactures/conversation/data/models/conversations_model.dart';
+import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
+import 'package:message_service/feactures/message/domain/entities/message_entity.dart';
+
+abstract class LocalConversationDataSource {
+  Future<void> insertConversation(ConversationEntity conv);
+  Future<List<ConversationEntity>> getConversations({String? type});
+  Future<void> deleteConversation(String conversationId);
+}
+
+class LocalConversationDataSourceImpl implements LocalConversationDataSource {
+  final LocalDatabase _db = LocalDatabase();
+
+  @override
+  Future<void> insertConversation(ConversationEntity conv) async {
+    final db = await _db.database;
+    final model = ConversationsModel.fromEntity(conv);
+    await db.insert('conversations', {
+      'id': model.id,
+      'title': model.title,
+      'user_id': model.userId,
+      'session_token': model.sessionToken,
+      'type': model.type,
+      'metadata': jsonEncode({
+        'created_at': model.createdAt?.toIso8601String(),
+        'updated_at': model.updatedAt?.toIso8601String(),
+      }),
+      'created_at': model.createdAt?.toIso8601String(),
+      'updated_at': model.updatedAt?.toIso8601String(),
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
+  }
+
+  @override
+  Future<List<ConversationEntity>> getConversations({String? type}) async {
+    final db = await _db.database;
+    List<Map<String, Object?>> rows;
+    if (type != null && type.isNotEmpty) {
+      rows = await db.query('conversations', where: 'type = ?', whereArgs: [type], orderBy: 'rowid DESC');
+    } else {
+      rows = await db.query('conversations', orderBy: 'rowid DESC');
+    }
+    return rows.map((r) {
+      DateTime? created;
+      DateTime? updated;
+      try {
+        created = r['created_at'] != null ? DateTime.tryParse(r['created_at'] as String)?.toUtc() : null;
+      } catch (_) {}
+      try {
+        updated = r['updated_at'] != null ? DateTime.tryParse(r['updated_at'] as String)?.toUtc() : null;
+      } catch (_) {}
+      return ConversationEntity(
+        id: r['id'] as String,
+        title: (r['title'] ?? '') as String?,
+        messages: <MessageEntity>[],
+        userId: (r['user_id'] ?? '') as String?,
+        sessionToken: r['session_token'] as String?,
+        createdAt: created,
+        updatedAt: updated,
+      );
+    }).toList();
+  }
+
+  @override
+  Future<void> deleteConversation(String conversationId) async {
+    final db = await _db.database;
+    await db.delete('conversations', where: 'id = ?', whereArgs: [conversationId]);
+  }
+}

--- a/lib/feactures/conversation/data/models/conversations_model.dart
+++ b/lib/feactures/conversation/data/models/conversations_model.dart
@@ -6,6 +6,7 @@ class ConversationsModel {
 
   final String id;
   final String title;
+  final String? type;
   final List<MessageEntity> messages;
   final String userId;
   final String? sessionToken;
@@ -15,6 +16,7 @@ class ConversationsModel {
   ConversationsModel({
     required this.id,
     required this.title,
+    this.type,
   required this.messages,
   required this.userId,
   this.sessionToken,
@@ -25,7 +27,8 @@ class ConversationsModel {
   factory ConversationsModel.fromJson(dynamic json) {
     return ConversationsModel(
       id: json['id'] ?? json['_id'] ?? '',
-      title: json['title'] ?? '',
+  title: json['title'] ?? '',
+  type: json['type'] ?? json['conversation_type'] ?? null,
       messages: (json['messages'] as List?)?.map((e) {
         if (e is Map<String, dynamic>) {
           return MessageEntity.fromJson(Map<String, dynamic>.from(e));
@@ -36,8 +39,8 @@ class ConversationsModel {
           return MessageEntity(id: '', content: '', sender: '', created_at: DateTime.now().toUtc());
         }
       }).toList() ?? <MessageEntity>[],
-      userId: json['userId'] ?? json['user_id'] ?? '',
-      sessionToken: json['session_token'] ?? json['sessionToken'] ?? null,
+    userId: json['userId'] ?? json['user_id'] ?? '',
+    sessionToken: json['session_token'] ?? json['sessionToken'] ?? null,
   createdAt: _parseDate(json['created_at'] ?? json['createdAt']),
   updatedAt: _parseDate(json['updated_at'] ?? json['updatedAt']),
     );
@@ -54,6 +57,7 @@ class ConversationsModel {
     return {
       'id': id,
       'title': title,
+      if (type != null) 'type': type,
   'messages': messages.map((m) => m.toJson()).toList(),
   'userId': userId,
   'session_token': sessionToken,
@@ -68,6 +72,7 @@ class ConversationsModel {
       title: entity.title ?? '',
   messages: entity.messages ?? [],
   userId: entity.userId ?? '',
+  type: entity.type,
   createdAt: entity.createdAt,
   updatedAt: entity.updatedAt,
     );
@@ -79,6 +84,7 @@ class ConversationsModel {
   messages: messages,
   userId: userId, // Aquí deberías asignar el userId correspondiente
   sessionToken: sessionToken,
+  type: type,
   createdAt: createdAt,
   updatedAt: updatedAt,
     );

--- a/lib/feactures/conversation/data/repository_impl/conversation_repository_impl.dart
+++ b/lib/feactures/conversation/data/repository_impl/conversation_repository_impl.dart
@@ -1,10 +1,12 @@
 import 'package:message_service/feactures/conversation/data/datasource/conversation_remote_datasource.dart';
+import 'package:message_service/feactures/conversation/data/datasource/local_conversation_datasource.dart';
 import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
 import 'package:message_service/feactures/conversation/domain/repository/conversation_reository.dart';
 
 
 class ConversationRepositoryImpl implements ConversationRepository {
   final ConversationRemoteDataSource remoteDataSource;
+  final LocalConversationDataSource localDataSource = LocalConversationDataSourceImpl();
 
 
   ConversationRepositoryImpl({
@@ -12,12 +14,18 @@ class ConversationRepositoryImpl implements ConversationRepository {
   });
 
   @override
-  Future<ConversationEntity> createConversation(String userId, String title, String token) async {
-    return remoteDataSource.createConversation(
+  Future<ConversationEntity> createConversation( String userId, String title, String token, String type ) async {
+    final conv = await remoteDataSource.createConversation(
       token: token,
       userId: userId,
       title: title,
+      type: type,
     );
+    // Persistir localmente para que aparezca en la lista tras reinicios
+    try {
+      await localDataSource.insertConversation(conv);
+    } catch (_) {}
+    return conv;
   }
 
   @override
@@ -26,16 +34,12 @@ class ConversationRepositoryImpl implements ConversationRepository {
     throw UnimplementedError();
   }
 
-  @override
-  Future<String> getConversationDetails(String conversationId) {
-    // TODO: implementar usando remoteDataSource cuando el endpoint esté disponible
-    throw UnimplementedError();
-  }
+  // getConversation implementado más abajo por la interfaz
 
   @override
-  Future<List<ConversationEntity>> getConversations() {
-    // TODO: implementar usando remoteDataSource cuando el endpoint esté disponible
-    throw UnimplementedError();
+  Future<List<ConversationEntity>> getConversations({String? type}) {
+    // Leer desde almacenamiento local (opcionalmente filtrando por type)
+    return localDataSource.getConversations(type: type);
   }
 
   @override
@@ -46,8 +50,18 @@ class ConversationRepositoryImpl implements ConversationRepository {
   
   @override
   Future<ConversationEntity> getAllConversations(String token, String userId) {
-    // TODO: implement getAllConversations
-    throw UnimplementedError();
+    // Consultar al servidor todas las conversaciones del usuario y sincronizar localmente
+    return remoteDataSource.getAllConversations(token: token, userId: userId).then((list) async {
+      // Guardar/actualizar localmente
+      for (var conv in list) {
+        try {
+          await localDataSource.insertConversation(conv);
+        } catch (_) {}
+      }
+      // Devolver la primera como placeholder (método firma discordante con uso actual)
+      if (list.isNotEmpty) return list.first;
+      throw Exception('No conversations found');
+    });
   }
   
   @override

--- a/lib/feactures/conversation/domain/entities/converstion_entity.dart
+++ b/lib/feactures/conversation/domain/entities/converstion_entity.dart
@@ -7,6 +7,7 @@ class ConversationEntity {
   final List<MessageEntity>? messages;
   final String? userId;
   final String? sessionToken;
+  final String? type;
   final DateTime? createdAt; // token para sesiones anónimas
   final DateTime? updatedAt; // token para sesiones anónimas
 
@@ -16,6 +17,7 @@ class ConversationEntity {
     required this.messages,
     required this.userId,
     this.sessionToken,
+    this.type,
     this.createdAt,
     this.updatedAt,
   });

--- a/lib/feactures/conversation/domain/repository/conversation_reository.dart
+++ b/lib/feactures/conversation/domain/repository/conversation_reository.dart
@@ -3,8 +3,10 @@
 import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
 
 abstract class ConversationRepository {
-  Future<ConversationEntity> createConversation(String userId, String title, String token);
-  Future<List<ConversationEntity>> getConversations();
+  /// Crea una conversación. `type` es opcional y puede ser 'anonymous', 'sales' o 'tecnico'
+  /// En la capa remota se mapeará a los tokens esperados por el backend (por ejemplo 'anonimo').
+  Future<ConversationEntity> createConversation(String userId, String title, String token, String type );
+  Future<List<ConversationEntity>> getConversations({String? type});
   Future<void> deleteConversation(String conversationId);
   Future<void> updateConversation(String conversationId, String title, String description);
   Future<String> getConversation(String conversationId);  

--- a/lib/feactures/conversation/domain/use_case/get_conversations_use_case.dart
+++ b/lib/feactures/conversation/domain/use_case/get_conversations_use_case.dart
@@ -11,8 +11,8 @@ class GetConversationsUseCase {
     return await _conversationRepository.getConversations();
   }
 
-  Future<ConversationEntity?> createConveersation(String userId, String title, String token) async {
-    return await _conversationRepository.createConversation( userId, title, token );
+  Future<ConversationEntity?> createConveersation(String userId, String title, String token, String type) async {
+    return await _conversationRepository.createConversation( userId, title, token, type );
   }
 
 }

--- a/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_bloc.dart
@@ -1,5 +1,5 @@
 import 'package:bloc/bloc.dart';
-import 'package:message_service/feactures/conversation/data/datasource/conversation_remote_datasource.dart';
+import 'package:message_service/feactures/conversation/domain/repository/conversation_reository.dart';
 import 'package:message_service/feactures/conversation/domain/entities/converstion_entity.dart';
 import 'package:meta/meta.dart';
 import 'package:message_service/core/session_manager.dart';
@@ -10,9 +10,9 @@ part 'conversation_event.dart';
 part 'conversation_state.dart';
 
 class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
-  final ConversationRemoteDataSource conversationDataSource;
+  final ConversationRepository conversationRepository;
 
-  ConversationBloc({required this.conversationDataSource}) : super(ConversationInitial()) {
+  ConversationBloc({required this.conversationRepository}) : super(ConversationInitial()) {
     on<CreateConversationEvent>(_onCreateConversation);
     on<LoadConversationsEvent>(_onLoadConversations);
     on<DeleteConversationEvent>(_onDeleteConversation);
@@ -36,7 +36,8 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       } catch (_) {}
       // Intentar borrar en servidor; si falla, reportar el error pero no hacer rollback local
       try {
-        await conversationDataSource.deleteConversation(token: e.token, conversationId: id, sessionToken: e.sessionToken);
+  // repository.deleteConversation should remove remotely and we also remove local state above
+  await conversationRepository.deleteConversation(id);
       } catch (err) {
         emit(ConversationErrorState(message: 'Error al eliminar en servidor: ${err.toString()}'));
       }
@@ -47,12 +48,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     final previous = state;
     emit(ConversationLoadingState());
     try {
-      final newConv = await conversationDataSource.createConversation(
-        token: event.token,
-        userId: event.userId,
-        title: event.title,
-        type: (event as dynamic).type,
-      );
+  final newConv = await conversationRepository.createConversation(event.userId ?? '', event.title, event.token, event.type);
 
       // If backend returned a session token (conversación anónima), store and connect
       // Only store session_token when the creation was anonymous (no userId provided)
@@ -83,12 +79,14 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     try {
       List<ConversationEntity> list;
       if (event.type != null && event.type!.isNotEmpty) {
-        list = await conversationDataSource.getConversations(token: event.token, type: event.type);
+        // Pedir al repositorio conversaciones locales filtrando por tipo
+        list = await conversationRepository.getConversations(type: event.type);
       } else if ((event as dynamic).userId != null) {
-        // fallback to getAllConversations if userId provided
-        list = await conversationDataSource.getAllConversations(token: event.token, userId: (event as dynamic).userId);
+        // fallback: fetch remote and sync local via repository
+        final conv = await conversationRepository.getAllConversations(event.token, (event as dynamic).userId);
+        list = [conv];
       } else {
-        list = await conversationDataSource.getConversations(token: event.token);
+        list = await conversationRepository.getConversations();
       }
       emit(ConversationLoadedState(conversations: list));
     } catch (e) {

--- a/lib/feactures/conversation/presentation/bloc/conversation_event.dart
+++ b/lib/feactures/conversation/presentation/bloc/conversation_event.dart
@@ -15,7 +15,7 @@ class CreateConversationEvent extends ConversationEvent {
 		required this.token,
 		required this.userId,
 		required this.title,
-		this.type,
+		required this.type,
 	});
 }
 

--- a/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
+++ b/lib/feactures/conversation/presentation/ui/pages/conversation_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:message_service/feactures/auth/presentation/bloc/auth_bloc.dart';
 import 'package:message_service/feactures/conversation/presentation/bloc/conversation_bloc.dart';
 import 'package:message_service/feactures/auth/presentation/ui/pages/login_page.dart';
+import 'package:message_service/core/session_manager.dart';
+import 'package:message_service/feactures/message/presentation/ui/pages/message_page.dart';
 
 // Página menú según rol (minimal y estable)
 class ConversationPage extends StatelessWidget {
@@ -49,7 +51,7 @@ class ConversationPage extends StatelessWidget {
                 title: 'Conversaciones anónimas',
                 icon: Icons.person_outline,
                 color: Colors.grey,
-                onTap: () => _openList(context, 'anonymous'),
+                onTap: () => _openList(context, 'anonimo'),
               ),
             ],
           ),
@@ -159,16 +161,80 @@ class _RoleCard extends StatelessWidget {
   }
 }
 
-class ConversationListPage extends StatelessWidget {
+class ConversationListPage extends StatefulWidget {
   final String type;
   const ConversationListPage({super.key, required this.type});
 
   @override
+  State<ConversationListPage> createState() => _ConversationListPageState();
+}
+
+class _ConversationListPageState extends State<ConversationListPage> {
+  @override
+  void initState() {
+    super.initState();
+    // Cargar conversaciones del tipo solicitado después del primer frame
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final token = SessionManager().sessionToken ?? '';
+      context.read<ConversationBloc>().add(LoadConversationsEvent(token: token, type: widget.type));
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Detectar si el usuario está autenticado para mostrar botón de login en anónimos
+    final authState = context.read<AuthBloc>().state;
+    final bool isAuthenticated = authState is AuthAuthenticatedState;
+
     return Scaffold(
-      appBar: AppBar(title: Text('Lista de $type')),
-      body: Center(child: Text('Aquí iría la lista de conversaciones de tipo "$type"')),
-      floatingActionButton: _NewConversationFab(type: type),
+      appBar: AppBar(
+        title: Text('Lista de ${widget.type}'),
+        actions: [
+          // Si es lista anónima y no está autenticado, mostrar botón para ir al login
+          if ((widget.type == 'anonymous' || widget.type == 'anonimo') && !isAuthenticated)
+            TextButton(
+              onPressed: () => Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => Login())),
+              child: const Text('Iniciar sesión', style: TextStyle(color: Colors.white)),
+            ),
+        ],
+      ),
+      body: BlocBuilder<ConversationBloc, ConversationState>(
+        builder: (context, state) {
+          if (state is ConversationLoadingState) return const Center(child: CircularProgressIndicator());
+          if (state is ConversationLoadedState) {
+            final convs = state.conversations;
+            if (convs.isEmpty) return Center(child: Text('No hay conversaciones de tipo "${widget.type}"'));
+            return ListView.builder(
+              itemCount: convs.length,
+              itemBuilder: (ctx, i) {
+                final c = convs[i];
+                return ListTile(
+                  title: Text(c.title ?? '(sin título)'),
+                  subtitle: Text(c.id),
+                  onTap: () {
+                    try {
+                      Navigator.push(
+                        ctx,
+                        MaterialPageRoute(
+                          builder: (_) => MessagePage(conversationId: c.id, title: c.title ?? 'Chat'),
+                        ),
+                      );
+                    } catch (e) {
+                      // Mostrar snackbar con detalle para ayudar a depurar en tiempo de ejecución
+                      try {
+                        ScaffoldMessenger.of(ctx).showSnackBar(SnackBar(content: Text('Error al abrir chat: ${e.toString()}')));
+                      } catch (_) {}
+                    }
+                  },
+                );
+              },
+            );
+          }
+          if (state is ConversationErrorState) return Center(child: Text('Error: ${state.message}'));
+          return const SizedBox.shrink();
+        },
+      ),
+      floatingActionButton: _NewConversationFab(type: widget.type),
     );
   }
 }
@@ -202,7 +268,7 @@ class _NewConversationFab extends StatelessWidget {
         final authState = context.read<AuthBloc>().state;
         if (authState is AuthAuthenticatedState) {
           final user = authState.user;
-          if (type != 'anonymous' && !user.hasRole(type)) {
+          if (type != 'anonimo' && !user.hasRole(type)) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('No tienes permisos para crear conversaciones de tipo "$type".')));
             return;
           }
@@ -223,7 +289,7 @@ class _NewConversationFab extends StatelessWidget {
             if (goLogin == true) Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => Login()));
             return;
           }
-          context.read<ConversationBloc>().add(CreateConversationEvent(token: '', userId: '', title: result, type: 'anonymous'));
+          context.read<ConversationBloc>().add(CreateConversationEvent(token: '', userId: '', title: result, type: 'anonimo'));
         }
       },
     );

--- a/lib/feactures/message/presentation/ui/pages/message_page.dart
+++ b/lib/feactures/message/presentation/ui/pages/message_page.dart
@@ -41,9 +41,10 @@ class _MessagePageState extends State<MessagePage> {
   void initState() {  
     super.initState();
   _scrollController = ScrollController();
+  WidgetsBinding.instance.addPostFrameCallback((_) {
   context.read<MessageBloc>().add(ConnectServerEvent());
-  // Start listening for incoming messages (listen once)
   context.read<MessageBloc>().add(LoadMessageEvent());
+});
     // Inicializar mensajes si vienen como parámetro
     final authState = context.read<AuthBloc>().state;
     if (widget.initialMessages != null && widget.initialMessages!.isNotEmpty) {
@@ -96,16 +97,7 @@ class _MessagePageState extends State<MessagePage> {
     // Aquí podrías inicializar la conexión al servidor o cualquier otra configuración necesaria.
   }
 
-  bool _isMine(Map<String, dynamic> m, dynamic authState) {
-    final sender = m['sender']?.toString() ?? '';
-  // merged temporals (debug prints removed)
-    // Scroll after merging temporals
-  WidgetsBinding.instance.addPostFrameCallback((_) { _scrollToEnd(); });
-    if (authState is AuthAuthenticatedState) {
-      return sender == authState.user.id || sender == authState.user.role;
-    }
-    return false;
-  }
+  // _isMine removed: message ownership is determined inline where needed.
 
   String _toIsoTimestamp(dynamic raw) {
     if (raw == null) return DateTime.now().toUtc().toIso8601String();
@@ -220,7 +212,7 @@ class _MessagePageState extends State<MessagePage> {
 
   void _sendMessage() {
     final text = _controller.text.trim();
-  if (text.isNotEmpty) {
+    if (text.isNotEmpty) {
       setState(() {
         final authStateNow = context.read<AuthBloc>().state;
         final senderId = (authStateNow is AuthAuthenticatedState) ? authStateNow.user.id.toString() : 'local';
@@ -231,33 +223,18 @@ class _MessagePageState extends State<MessagePage> {
           final t = DateTime.tryParse((m['timestamp'] ?? m['created_at'] ?? '').toString());
           if (t != null && t.isAfter(maxTs)) maxTs = t;
         }
-  final nowTs = maxTs.add(const Duration(milliseconds: 1)).toIso8601String();
-  messages.add({'text': text, 'isMe': true, 'timestamp': nowTs, 'created_at': nowTs, 'sender': senderId, 'local': true, 'seq': _seqCounter++, 'source': 'local'});
+        final nowTs = maxTs.add(const Duration(milliseconds: 1)).toIso8601String();
+        messages.add({'text': text, 'isMe': true, 'timestamp': nowTs, 'created_at': nowTs, 'sender': senderId, 'local': true, 'seq': _seqCounter++, 'source': 'local'});
         _normalizeAndSortMessages();
       });
 
       _controller.clear();
-  // Scroll to the newly added message
-  WidgetsBinding.instance.addPostFrameCallback((_) { _scrollToEnd(); });
+      // Scroll to the newly added message
+      WidgetsBinding.instance.addPostFrameCallback((_) { _scrollToEnd(); });
     }
   }
 
-  void _debugDump(String tag) {
-    try {
-      final sample = messages.take(12).map((m) {
-        final tsRaw = (m['timestamp'] ?? m['created_at'] ?? '').toString();
-        final parsed = DateTime.tryParse(tsRaw);
-        final ts = parsed != null ? parsed.toUtc().toIso8601String() : 'INVALID';
-        final src = (m['source'] ?? 'unknown').toString();
-        final seq = (m['seq'] ?? 0).toString();
-        final isMe = (m['isMe'] ?? false).toString();
-        final text = (m['text'] ?? '').toString();
-        final short = text.length > 24 ? text.substring(0, 24) + '...' : text;
-        return '{seq:$seq src:$src isMe:$isMe ts:$ts text:"$short"}';
-      }).join('\n');
-      debugPrint('DBG DUMP $tag count=${messages.length}\n$sample');
-    } catch (_) {}
-  }
+  // _debugDump removed: kept out of production code. Re-add if needed for debugging.
 
   @override
   Widget build(BuildContext context) {
@@ -314,6 +291,22 @@ class _MessagePageState extends State<MessagePage> {
               });
               WidgetsBinding.instance.addPostFrameCallback((_) { _scrollToEnd(); });
             } catch (_) {}
+          }
+          // Generic error handling: if the state type name contains 'Error' try to show a message
+          final stName = state.runtimeType.toString().toLowerCase();
+          if (stName.contains('error') || stName.contains('senderror')) {
+            try {
+              final msg = (state as dynamic).message ?? 'Error al enviar mensaje';
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(SnackBar(content: Text(msg), backgroundColor: Colors.red));
+            } catch (_) {
+              try {
+                ScaffoldMessenger.of(context)
+                  ..hideCurrentSnackBar()
+                  ..showSnackBar(const SnackBar(content: Text('Error al enviar mensaje'), backgroundColor: Colors.red));
+              } catch (_) {}
+            }
           }
         },
         child: Column(
@@ -391,6 +384,7 @@ class _MessagePageState extends State<MessagePage> {
                   Expanded(
                     child: TextField(
                       controller: _controller,
+                      onSubmitted: (_) => _sendMessage(),
                       decoration: const InputDecoration(
                         hintText: 'Escribe un mensaje...',
                         border: OutlineInputBorder(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:message_service/feactures/auth/presentation/bloc/auth_bloc.dart'
 import 'package:message_service/feactures/auth/presentation/ui/pages/login_page.dart';
 import 'package:message_service/feactures/conversation/data/datasource/conversation_remote_datasource.dart';
 import 'package:message_service/feactures/conversation/presentation/bloc/conversation_bloc.dart';
+import 'package:message_service/feactures/conversation/data/repository_impl/conversation_repository_impl.dart';
 import 'package:message_service/feactures/message/data/datasource/message_datasource.dart';
 import 'package:message_service/feactures/message/presentation/bloc/message_bloc.dart';
 import 'package:message_service/feactures/message/data/repository_impl/message_repository_impl.dart';
@@ -54,9 +55,9 @@ class MyApp extends StatelessWidget {
         ),
         BlocProvider<ConversationBloc>(
           create: (_) {
-            return ConversationBloc(
-              conversationDataSource: ConversationRemoteDataSourceImpl(),
-            );
+            final remote = ConversationRemoteDataSourceImpl();
+            final repo = ConversationRepositoryImpl(remoteDataSource: remote);
+            return ConversationBloc(conversationRepository: repo);
           }
         ),
       ],


### PR DESCRIPTION
Se implementa la persistencia local para las conversaciones, se añade compatibilidad con el campo `type` de conversación en todo el modelo de datos y se refactoriza el repositorio de conversaciones y el BLoC para utilizar estas nuevas funciones. Las principales mejoras son la creación de una fuente de datos local para las conversaciones, la propagación del atributo `type` y las actualizaciones de las capas de repositorio y presentación para admitir el almacenamiento local y el filtrado por tipo.

**Persistencia local e integración de la fuente de datos:**

* Se añadió una nueva tabla `conversations` (con una columna `type`) a la base de datos SQLite local mediante `LocalDatabase` y se implementó `LocalConversationDataSource` para insertar, recuperar (opcionalmente por tipo) y eliminar conversaciones localmente. (`lib/core/local_database.dart` [[1]](diffhunk://#diff-5ddc04e2cf50dec577089910ee7a3fe21e7f9008b58c22e5c6b10850406963d7R41-R53) `lib/feactures/conversation/data/datasource/local_conversation_datasource.dart` [[2]](diffhunk://#diff-5e64f613a7ff1437191195a162fdebc74b87d8cb93a02e05e170eca707bcd83dR1-R72)

* Se refactorizó `ConversationRepositoryImpl` para usar `LocalConversationDataSource` para almacenar y recuperar conversaciones localmente, incluyendo Sincronización con datos remotos y compatibilidad con filtrado por tipo. (`lib/feactures/conversation/data/repository_impl/conversation_repository_impl.dart` [[1]](diffhunk://#diff-7f76a4a9898b89f45b3c8d3f35fe06fbbf3132c391b8c6f6beaa8dfda25e7907R2-R28) [[2]](diffhunk://#diff-7f76a4a9898b89f45b3c8d3f35fe06fbbf3132c391b8c6f6beaa8dfda25e7907L29-R42) [[3]](diffhunk://#diff-7f76a4a9898b89f45b3c8d3f35fe06fbbf3132c391b8c6f6beaa8dfda25e7907L49-R64)

**Propagación del tipo de conversación:**

* Se añadió un campo `type` que acepta valores nulos a `ConversationEntity` y `ConversationsModel`, se actualizó la serialización/deserialización y se aseguró que el `type` se gestione en todos los constructores y métodos relevantes. (`lib/feactures/conversation/domain/entities/converstion_entity.dart`) [[1]](diffhunk://#diff-03be09c1b766e0e87c82863aa1af6b6ffa0959ecf89978a1a1e0fa9042fbc33aR10) [[2]](diffhunk://#diff-03be09c1b766e0e87c82863aa1af6b6ffa0959ecf89978a1a1e0fa9042fbc33aR20); `lib/características/conversación/datos/modelos/conversaciones_modelo.dart` [[3]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R9) [[4]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R19) [[5]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R31) [[6]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R60) [[7]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R75) [[8]](diffhunk://#diff-a377dee8aacb93b98bbe5b52922a07f21c0a9359052bc766dcdd8f6501853e09R87)

* Se actualizó la fuente de datos remota para requerir y enviar correctamente Campo `type` al crear conversaciones. (`lib/feactures/conversation/data/datasource/conversation_remote_datasource.dart` [[1]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48L12-R12) [[2]](diffhunk://#diff-51fe17cf8d3a720808b79efd9739ee493353835f68752dd6aedb861d89cc5e48R62-L64)

**Actualizaciones del repositorio y de los casos de uso:**

* Se modificaron las interfaces del repositorio y de los casos de uso para requerir el parámetro `type` al crear conversaciones y permitir el filtrado al recuperarlas. (`lib/feactures/conversation/domain/repository/conversation_reository.dart` [[1]](diffhunk://#diff-fa172ab9128970c096d2139e26513606a1d72932f5ff452551cad9d9f6d3183fL6-R9); `lib/feactures/conversation/domain/use_case/get_conversations_use_case.dart` [[2]](diffhunk://#diff-2acd768cb1655cb13f94caa5e25414bf0c64c04a1c8ae8dbf467c66ac8437a15L14-R15)

**Refactorización de BLoC y UI:**

* Refactorizado `ConversationBloc` usa el repositorio en lugar de la fuente de datos remota directamente, se actualizó el manejo de eventos para admitir el campo `type` y se garantizó el uso de persistencia local en todo momento. (`lib/feactures/conversation/presentation/bloc/conversation_bloc.dart` [[1]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bL2-R2) [[2]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bL13-R15) [[3]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bL39-R40) [[4]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bL50-R51) [[5]](diffhunk://#diff-2198db3d04c49b0fac0992aa4b8e6bc70b94945655a2ccb6b8439b269f93753bL86-R89); `lib/feactures/conversation/presentation/bloc/conversation_event.dart` [[6]](diffhunk://#diff-704ca347ecf6846f054a5fc6f2ee898b64c4f47b9aad53dbfd31e2a6d70d3e32L18-R18)

**Ajuste menor en la interfaz de usuario:**

* Se cambió el valor del filtro para conversaciones anónimas en la interfaz de usuario de «anonymous» a «anonimo» para cumplir con las expectativas del backend. (`lib/feactures/conversation/presentation/ui/pages/conversation_page.dart`) [[1]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2R6-R7) [[2]](diffhunk://#diff-fd3b31fe53ee0a94ccc87d713debc9dbd13233b8f39b00953269f43e573b74e2L52-R54)