### PR TITLE
previsualizacion de imagenes y pdf en chat

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -11,8 +11,8 @@ class AppConfig {
   // - Dispositivo físico en red local: 'http://TU_IP:3000' (ej: 'http://192.168.1.100:3000')
   // - Dev Tunnels / Producción: 'https://3ztt6mfl-3000.brs.devtunnels.ms'
   // - Production con dominio real: 'https://24.144.109.91:3000'
-  //static const String baseUrl = 'http://24.144.109.91:3000/api/v1';
-  static const String baseUrl = 'https://l002n256-3000.brs.devtunnels.ms/api/v1';
+  static const String baseUrl = 'http://24.144.109.91:3000/api/v1';
+  //static const String baseUrl = 'https://l002n256-3000.brs.devtunnels.ms/api/v1';
   
   // Cliente HTTP que acepta certificados no confiables (solo para desarrollo)
   // ⚠️ PRODUCCIÓN: Eliminar badCertificateCallback y usar certificado SSL válido

--- a/lib/feactures/message/presentation/ui/widgets/message_content.dart
+++ b/lib/feactures/message/presentation/ui/widgets/message_content.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:flutter_cached_pdfview/flutter_cached_pdfview.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'package:url_launcher/url_launcher.dart';
 
 class MessageContent extends StatelessWidget {
@@ -90,7 +91,7 @@ class MessageContent extends StatelessWidget {
         if (_isImage(cleaned) || _isPdf(cleaned)) {
           parts.add(_MessagePart.media(cleaned));
         } else {
-          parts.add(_MessagePart.text(cleaned));
+          parts.add(_MessagePart.text(match.group(0) ?? cleaned));
         }
       }
 
@@ -140,29 +141,84 @@ class MessageContent extends StatelessWidget {
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: Colors.grey.shade300),
         ),
-        child: const Center(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [Icon(Icons.picture_as_pdf), SizedBox(width: 8), Flexible(child: Text('Abrir PDF'))],
-          ),
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          children: [
+            // Preview inline: muestra el contenido del PDF dentro de la burbuja.
+            IgnorePointer(
+              child: PDF(
+                enableSwipe: false,
+                pageFling: false,
+                pageSnap: true,
+                defaultPage: 0,
+              ).cachedFromUrl(
+                url,
+                placeholder: (progress) => Center(
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    value: (progress / 100).clamp(0.0, 1.0),
+                  ),
+                ),
+                errorWidget: (_) => const Center(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [Icon(Icons.picture_as_pdf), SizedBox(width: 8), Flexible(child: Text('No se pudo previsualizar'))],
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                color: Colors.black.withValues(alpha: 0.45),
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.open_in_full, size: 14, color: Colors.white),
+                    SizedBox(width: 6),
+                    Text('Tocar para abrir PDF', style: TextStyle(color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600)),
+                  ],
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
 
   Widget _buildLinkifiedText(BuildContext context, String value) {
-    return Linkify(
-      text: value,
-      onOpen: (link) async {
-        final cleaned = _cleanUrl(link.url);
-        final uri = Uri.tryParse(cleaned);
+    final base = MarkdownStyleSheet.fromTheme(Theme.of(context));
+    final styleSheet = base.copyWith(
+      p: TextStyle(fontSize: 13, color: textColor ?? Colors.black, height: 1.25),
+      tableHead: TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700, color: textColor ?? Colors.black),
+      tableBody: TextStyle(fontSize: 12.5, color: textColor ?? Colors.black),
+      tableBorder: TableBorder.all(color: Colors.grey.shade300, width: 0.8),
+      a: const TextStyle(color: Colors.blueAccent, decoration: TextDecoration.underline),
+      code: TextStyle(fontFamily: 'monospace', fontSize: 12.5, color: Colors.indigo.shade900),
+      blockquote: TextStyle(color: Colors.grey.shade700, fontStyle: FontStyle.italic),
+      blockquoteDecoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(8),
+        border: Border(left: BorderSide(color: Colors.grey.shade400, width: 3)),
+      ),
+    );
+
+    return MarkdownBody(
+      data: value,
+      selectable: true,
+      extensionSet: md.ExtensionSet.gitHubWeb,
+      styleSheet: styleSheet,
+      onTapLink: (textLink, href, title) async {
+        final url = _cleanUrl(href ?? textLink);
+        final uri = Uri.tryParse(url);
         if (uri != null && await canLaunchUrl(uri)) {
           await launchUrl(uri, mode: LaunchMode.externalApplication);
         }
       },
-      options: const LinkifyOptions(humanize: false),
-      style: TextStyle(fontSize: 13, color: textColor ?? Colors.black),
-      linkStyle: const TextStyle(color: Colors.blueAccent),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,7 +401,7 @@ packages:
     source: hosted
     version: "1.3.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A new Flutter project."
 
 publish_to: 'Dario Ramirez'
 
-version: 2.0.1+5
+version: 3.0.1+6
 
 environment:
   sdk: ^3.7.0
@@ -29,6 +29,7 @@ dependencies:
   photo_view: ^0.14.0
   flutter_cached_pdfview: ^0.4.3
   flutter_linkify: ^6.0.0
+  markdown: ^7.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Actualiza el widget de contenido de mensajes para mejorar la visualización de mensajes de texto y PDF, y cambia la detección de enlaces simples por la representación completa en Markdown. También actualiza la versión de la aplicación y modifica la URL de la API de backend para desarrollo.

**Mejoras en la representación de mensajes:**

* Reemplaza el uso de `flutter_linkify` por `flutter_markdown` y el paquete `markdown`, lo que permite que los mensajes admitan el formato Markdown completo (incluidos enlaces, tablas, código y citas). El método `_buildLinkifiedText` ahora usa `MarkdownBody` para una representación de texto más rica y una mejor gestión de enlaces. [[1]](diffhunk://#diff-1161b04a207a80a49f7b76fda5ca6beb31b35f52ba3f16099825b08bf5413a59L5-R6) [[2]](diffhunk://#diff-1161b04a207a80a49f7b76fda5ca6beb31b35f52ba3f16099825b08bf5413a59L143-L165) [[3]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R32)
* Mejora la vista previa de PDF en las burbujas de mensaje mostrando una miniatura del PDF integrada con una superposición al tocar, y un mensaje de error más claro si la vista previa falla.

**Configuración y control de versiones:**

* Cambia la `baseUrl` predeterminada en `AppConfig` a la dirección IP de producción, comentando la URL de los túneles de desarrollo.

* Actualiza la versión de la aplicación a `3.0.1+6` en `pubspec.yaml`.

**Corrección de errores:**

* Corrige un error menor en el análisis de partes de mensajes asegurando que se utilice la subcadena correcta para las partes de texto.